### PR TITLE
fix: Apply critical Celery deployment fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
     container_name: postgresql_profiler_celery_monitoring
     environment:
       FLASK_ENV: ${FLASK_ENV:-production}
-      PYTHONPATH: /app:/app/src
+      PYTHONPATH: /app/src
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgresql_profiler
       REDIS_URL: redis://redis:6379/0
       CELERY_BROKER_URL: redis://redis:6379/0
@@ -165,7 +165,7 @@ services:
     container_name: postgresql_profiler_celery_ml
     environment:
       FLASK_ENV: ${FLASK_ENV:-production}
-      PYTHONPATH: /app:/app/src
+      PYTHONPATH: /app/src
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgresql_profiler
       REDIS_URL: redis://redis:6379/0
       CELERY_BROKER_URL: redis://redis:6379/0
@@ -210,7 +210,7 @@ services:
     container_name: postgresql_profiler_celery_beat
     environment:
       FLASK_ENV: ${FLASK_ENV:-production}
-      PYTHONPATH: /app:/app/src
+      PYTHONPATH: /app/src
       DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgresql_profiler
       REDIS_URL: redis://redis:6379/0
       CELERY_BROKER_URL: redis://redis:6379/0
@@ -323,6 +323,61 @@ services:
     restart: unless-stopped
     profiles:
       - monitoring
+
+  # Celery Workers для фоновых задач
+  celery_worker_monitoring:
+    build:
+      context: ./postgresql_profiler
+      dockerfile: Dockerfile
+    container_name: postgresql_profiler_celery_monitoring
+    command: celery -A src.main.celery worker --loglevel=info --queues=monitoring --concurrency=2
+    environment:
+      FLASK_ENV: ${FLASK_ENV:-production}
+      PYTHONPATH: /app/src
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgresql_profiler
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    volumes:
+      - ./postgresql_profiler/app_logs:/app/logs
+    networks:
+      - profiler_network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  celery_worker_ml:
+    build:
+      context: ./postgresql_profiler
+      dockerfile: Dockerfile
+    container_name: postgresql_profiler_celery_ml
+    command: celery -A src.main.celery worker --loglevel=info --queues=ml_processing --concurrency=1
+    environment:
+      FLASK_ENV: ${FLASK_ENV:-production}
+      PYTHONPATH: /app/src
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgresql_profiler
+      REDIS_URL: redis://redis:6379/0
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+      # ML настройки
+      ML_MODEL_DIR: /app/ml_models
+      ML_MIN_TRAIN_SIZE: ${ML_MIN_TRAIN_SIZE:-50}
+      ML_RETRAIN_THRESHOLD: ${ML_RETRAIN_THRESHOLD:-0.8}
+      ML_CACHE_TTL: ${ML_CACHE_TTL:-3600}
+    volumes:
+      - ml_models:/app/ml_models
+      - ./postgresql_profiler/app_logs:/app/logs
+    networks:
+      - profiler_network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
 
 volumes:
   postgres_data:

--- a/postgresql_profiler/src/main.py
+++ b/postgresql_profiler/src/main.py
@@ -517,6 +517,9 @@ def make_celery(app: Flask) -> Celery:
 # Создание приложения на уровне модуля для Gunicorn
 app = create_app(os.getenv('FLASK_ENV', 'production'))
 
+# Создание объекта celery на уровне модуля для Celery workers
+celery = make_celery(app)
+
 if __name__ == '__main__':
     # Создание таблиц базы данных
     with app.app_context():


### PR DESCRIPTION
- Add celery object at module level in main.py
- Add Celery workers configuration in docker-compose.yml
- Fix PYTHONPATH for proper imports
- Resolves 'Unable to load celery application' error